### PR TITLE
Enable Hetzner Cloud Controller Manager

### DIFF
--- a/.fixtures/hccm_disable.tfvars
+++ b/.fixtures/hccm_disable.tfvars
@@ -1,0 +1,5 @@
+hcloud_token      = "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+ssh_pub_key       = "foo"
+ssh_priv_key_path = "foo"
+domain            = "example.com"
+hccm_enable       = false

--- a/.fixtures/hccm_enable.tfvars
+++ b/.fixtures/hccm_enable.tfvars
@@ -1,0 +1,5 @@
+hcloud_token      = "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+ssh_pub_key       = "foo"
+ssh_priv_key_path = "foo"
+domain            = "example.com"
+hccm_enable       = true

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -44,7 +44,7 @@ jobs:
     # Generates an execution plan for Terraform
     - name: Terraform Plan
       run: |
-        terraform plan -input=false -var-file '.fixtures/defaults.tfvars'
-        terraform plan -input=false -var-file '.fixtures/single.tfvars'
-        terraform plan -input=false -var-file '.fixtures/both.tfvars'
-        terraform plan -input=false -var-file '.fixtures/both_no_workers.tfvars'
+        for fixture in .fixtures/*.tfvars;
+        do
+          terraform plan -input=false -var-file $fixture
+        done

--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ Other settings you can set in terraform.tfvars
 * worker\_server\_image - Hetzner's server image. Defaults to Debian 11. Refer to worker\_variables.tf for valid values
 * worker\_server\_location - Hetzner's server location. Defaults to Falkenstein. Refer to worker\_variables.tf for valid values
 * k0s\_version - The k0s version to target. Valid values: 1.27.2+k0s.0 for now
+* hccm_enable - Bool, defaults to true. Enables the Hetzner Cloud Controller Manager. CAUTION: Do not enable in dedicated root
 
 # TODO
 

--- a/k0s.tf
+++ b/k0s.tf
@@ -23,6 +23,10 @@ resource "k0s_cluster" "k0s1" {
       {
         role        = "worker"
         environment = { "ROLE" = "worker" }
+        install_flags = var.hccm_enable ? [
+          "--enable-cloud-provider",
+          "--kubelet-extra-args=\"--cloud-provider=external\""
+        ] : []
         ssh = {
           address  = address
           port     = 22

--- a/variables.tf
+++ b/variables.tf
@@ -1,7 +1,13 @@
 variable "hcloud_token" {
+  type        = string
   sensitive   = true # Requires terraform >= 0.14
   description = "Value of the Hetzner token"
-  type        = string
+}
+
+variable "hccm_enable" {
+  type        = bool
+  description = "Whether or not the Hetzner Cloud controller manager will be installed"
+  default     = true
 }
 
 variable "ssh_pub_key" {


### PR DESCRIPTION
Deploy the helm chart in kube-system and instruct the kubelets on the workers that we want to use an external cloud controller manager. Since for reasons, the helm chart doesn't create the secret, populate it via a terraform_data resource that keeps dependencies nicely in order