### PR TITLE
Support creating SSH keys by terraform

### DIFF
--- a/.fixtures/devkeys.tfvars
+++ b/.fixtures/devkeys.tfvars
@@ -1,0 +1,2 @@
+hcloud_token      = "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+domain            = "example.com"

--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -64,6 +64,26 @@ provider "registry.terraform.io/hashicorp/local" {
   ]
 }
 
+provider "registry.terraform.io/hashicorp/tls" {
+  version     = "4.0.4"
+  constraints = "4.0.4"
+  hashes = [
+    "h1:pe9vq86dZZKCm+8k1RhzARwENslF3SXb9ErHbQfgjXU=",
+    "zh:23671ed83e1fcf79745534841e10291bbf34046b27d6e68a5d0aab77206f4a55",
+    "zh:45292421211ffd9e8e3eb3655677700e3c5047f71d8f7650d2ce30242335f848",
+    "zh:59fedb519f4433c0fdb1d58b27c210b27415fddd0cd73c5312530b4309c088be",
+    "zh:5a8eec2409a9ff7cd0758a9d818c74bcba92a240e6c5e54b99df68fff312bbd5",
+    "zh:5e6a4b39f3171f53292ab88058a59e64825f2b842760a4869e64dc1dc093d1fe",
+    "zh:810547d0bf9311d21c81cc306126d3547e7bd3f194fc295836acf164b9f8424e",
+    "zh:824a5f3617624243bed0259d7dd37d76017097dc3193dac669be342b90b2ab48",
+    "zh:9361ccc7048be5dcbc2fafe2d8216939765b3160bd52734f7a9fd917a39ecbd8",
+    "zh:aa02ea625aaf672e649296bce7580f62d724268189fe9ad7c1b36bb0fa12fa60",
+    "zh:c71b4cd40d6ec7815dfeefd57d88bc592c0c42f5e5858dcc88245d371b4b8b1e",
+    "zh:dabcd52f36b43d250a3d71ad7abfa07b5622c69068d989e60b79b2bb4f220316",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}
+
 provider "registry.terraform.io/hetznercloud/hcloud" {
   version     = "1.41.0"
   constraints = "1.41.0"

--- a/README.md
+++ b/README.md
@@ -10,7 +10,10 @@ If you use Windows, go get a linux machine.
 
 Get terraform, clone this repo with git, cd into the dir
 
-Create a new SSH key
+You have 2 options now. Either rely on terraform to create SSH keys for you or
+create a new SSH key yourself.  Per terraform [docs for TLS provider](https://registry.terraform.io/providers/hashicorp/tls/latest/docs#secrets-and-terraform-state)
+the former is mostly for development purposes, so if you plan to use this for
+production, create an SSH key pair on your own. You can do so with the following command
 ```
 $ ssh-keygen -t ed25519 -f id_ed25519_k0s_hetzner_poc
 ```
@@ -20,12 +23,16 @@ Now, go to [Hetzner Cloud console](console.hetzner.cloud), create project, go to
 Create a file named terraform.tfvars and put inside the Token from Hetzner's portal and the public key as below. Note that this file is git-ignored
 ```
 hcloud_token = "API_TOKEN_HERE"
-ssh_pub_key = "SSH_KEY_HERE"
-ssh_priv_key_path = "path_to_priv_key_file"
-domain            = "example.com"
+domain       = "example.com"
 ```
 
-This are the absolute necessities, look below for all the tunables that you can configure using this file
+These are the absolute necessities, look below for all the tunables that you can configure using this file
+
+If you have created your own SSH key pair, add the following in that file
+```
+ssh_pub_key       = "SSH_KEY_HERE"
+ssh_priv_key_path = "path_to_priv_key_file"
+```
 
 Now, run the following to get the providers
 ```
@@ -47,7 +54,7 @@ Once you are sure that the demons have been exorcised create the resources
 $ SSH_KNOWN_HOSTS=/dev/null terraform apply -auto-approve
 ```
 
-Wait for the output and fetch the IPv6 and IPv4 addresses. Based on what you have of the 2, ssh to the node.
+Wait for the output and fetch the IPv6 and IPv4 addresses. Based on what you have of the 2, ssh to the nodes.
 Note that I am on purpose redirecting to /dev/null the host key as I don't want to keep it around for this PoC.
 
 ```
@@ -61,7 +68,7 @@ k0s itself, or via the kubeconfig file and standard tooling
 
 ### Internal use
 
-k0s is distribution of Kubernetes that has some interesting properties. Some basic commands:
+k0s is a distribution of Kubernetes that has some interesting properties. Some basic commands:
 
 List nodes
 ```
@@ -89,7 +96,7 @@ Delete pods
 # k0s kubectl delete pods --all
 ```
 
-And so on.
+And so on. All of these are meant to be run from a controller node.
 
 ### Standard tooling
 

--- a/variables.tf
+++ b/variables.tf
@@ -36,13 +36,15 @@ variable "prometheus_enable" {
 
 variable "ssh_pub_key" {
   type        = string
-  description = "Public SSH key for connecting to servers"
+  description = "Public SSH key for connecting to servers. If left empty, terraform will create a key pair for you"
+  default     = null
 }
 
 variable "ssh_priv_key_path" {
   type        = string
-  description = "The private part of the above"
+  description = "The private SSH for connecting to servers. If left empty, terraform will create a key pair for you"
   sensitive   = true
+  default     = null
 }
 
 variable "domain" {

--- a/versions.tf
+++ b/versions.tf
@@ -5,5 +5,9 @@ terraform {
       source  = "hetznercloud/hcloud"
       version = "1.41.0"
     }
+    tls = {
+      source  = "hashicorp/tls"
+      version = "4.0.4"
+    }
   }
 }


### PR DESCRIPTION
While inappropriate for running production workloads, creating
automatically SSH keys for dev environments can be useful. Support that
by utilizing the TLS provider by hashicorp and create an ED25519 key
pair and utilize it for everything
