### PR TITLE
Replace ferm with other solutions

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ Other settings you can set in terraform.tfvars
 - [x] Write more docs
 - [x] Support Debian 12
 - [ ] Upstream amended CSI driver helm chart
-- [ ] Replace ferm:
-  - [ ] workers: Move to Calico Host Endpoints and GlobalNetwork policies
-  - [ ] controllers: Move to hetzner's firewalling functionality.
+- [x] Replace ferm:
+  - [x] workers: Move to Calico Host Endpoints and GlobalNetwork policies
+  - [x] controllers: Move to hetzner's firewalling functionality.
 - [ ] Test PVC moves between nodes

--- a/configs-helm-chart/.helmignore
+++ b/configs-helm-chart/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/configs-helm-chart/Chart.yaml
+++ b/configs-helm-chart/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: configs-helm-chart
+description: A Helm chart to apply some Kubernetes stanza we require for this project
+type: application
+version: 0.1.0

--- a/configs-helm-chart/templates/NOTES.txt
+++ b/configs-helm-chart/templates/NOTES.txt
@@ -1,0 +1,1 @@
+Values applied successfully!

--- a/configs-helm-chart/templates/_helpers.tpl
+++ b/configs-helm-chart/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "configs-helm-chart.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "configs-helm-chart.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "configs-helm-chart.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "configs-helm-chart.labels" -}}
+helm.sh/chart: {{ include "configs-helm-chart.chart" . }}
+{{ include "configs-helm-chart.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "configs-helm-chart.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "configs-helm-chart.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "configs-helm-chart.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "configs-helm-chart.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/configs-helm-chart/templates/globalnetworkpolicy.yaml
+++ b/configs-helm-chart/templates/globalnetworkpolicy.yaml
@@ -3,7 +3,6 @@ apiVersion: crd.projectcalico.org/v1
 kind: GlobalNetworkPolicy
 metadata:
   name: {{ $policy }}
-#  annotations:
 spec:
   order: 0
   selector: has(k0s-worker)
@@ -14,7 +13,7 @@ spec:
     destination:
       {{- if $spec.port }}
       ports:
-      - {{ $spec.port }}
+        - {{ $spec.port | replace "-" ":" }}
       {{- end }}
     protocol: {{ upper $spec.proto }}
     source:
@@ -22,4 +21,5 @@ spec:
         {{- range $cidr := $spec.cidrs }}
         - {{ $cidr }}
         {{- end }}
+---
 {{- end }}

--- a/configs-helm-chart/templates/globalnetworkpolicy.yaml
+++ b/configs-helm-chart/templates/globalnetworkpolicy.yaml
@@ -1,0 +1,25 @@
+{{- range $policy, $spec := .Values.GlobalNetworkPolicies }}
+apiVersion: crd.projectcalico.org/v1
+kind: GlobalNetworkPolicy
+metadata:
+  name: {{ $policy }}
+#  annotations:
+spec:
+  order: 0
+  selector: has(k0s-worker)
+  types:
+  - Ingress
+  ingress:
+  - action: Allow
+    destination:
+      {{- if $spec.port }}
+      ports:
+      - {{ $spec.port }}
+      {{- end }}
+    protocol: {{ upper $spec.proto }}
+    source:
+      nets:
+        {{- range $cidr := $spec.cidrs }}
+        - {{ $cidr }}
+        {{- end }}
+{{- end }}

--- a/configs-helm-chart/templates/hostendpoint.yaml
+++ b/configs-helm-chart/templates/hostendpoint.yaml
@@ -14,4 +14,5 @@ metadata:
 spec:
   node: {{ $worker }}
   {{- toYaml $spec | nindent 2 }}
+---
 {{- end }}

--- a/configs-helm-chart/templates/hostendpoint.yaml
+++ b/configs-helm-chart/templates/hostendpoint.yaml
@@ -1,0 +1,17 @@
+{{- $dot := . -}}
+{{- range $worker, $spec := .Values.HostEndpoints.workers }}
+apiVersion: crd.projectcalico.org/v1
+kind: HostEndpoint
+metadata:
+  name: {{ $worker }}-hep
+  {{- with $dot.Values.HostEndpoints.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    kubernetes-host: {{ $worker }}
+    {{- include "configs-helm-chart.labels" $dot | nindent 4 }}
+spec:
+  node: {{ $worker }}
+  {{- toYaml $spec | nindent 2 }}
+{{- end }}

--- a/configs-helm-chart/templates/hostendpoint.yaml
+++ b/configs-helm-chart/templates/hostendpoint.yaml
@@ -9,7 +9,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   labels:
-    kubernetes-host: {{ $worker }}
+    k0s-worker: {{ $worker }}
     {{- include "configs-helm-chart.labels" $dot | nindent 4 }}
 spec:
   node: {{ $worker }}

--- a/configs-helm-chart/values.yaml
+++ b/configs-helm-chart/values.yaml
@@ -1,0 +1,17 @@
+HostEndpoints:
+  annotations: {}
+  workers: {}
+  # w1:
+  #   expectedIPs:
+  #     - 10.10.0.1
+  #     - 10.20.0.1
+  #   ports:
+  #     - name: some-port
+  #       port: 1234
+  #       protocol: TCP
+  #     - name: another-port
+  #       port: 5432
+  #       protocol: UDP
+  #   profiles:
+  #     - profile1
+  #     - profile2

--- a/configs-helm-chart/values.yaml
+++ b/configs-helm-chart/values.yaml
@@ -15,3 +15,15 @@ HostEndpoints:
   #   profiles:
   #     - profile1
   #     - profile2
+GlobalNetworkPolicies:
+  icmp-all:
+    proto: icmp
+    port: null
+    cidrs:
+      - 0.0.0.0/0
+      - ::/0
+  # policyname:
+  #   proto: TCP
+  #   port: 22
+  #   cidrs:
+  #     - 10.10.10.10/32

--- a/main.tf
+++ b/main.tf
@@ -64,6 +64,11 @@ module "controller_ips" {
 }
 
 locals {
+  worker_cidrs = compact(concat(
+    module.worker_ips.addresses["ipv6cidr"],
+    module.worker_ips.addresses["ipv4cidr"],
+    var.enable_private_network ? [var.network_subnet_ip_range] : [],
+  ))
   base_rules = {
     icmp = {
       proto = "icmp",
@@ -86,42 +91,27 @@ locals {
     bgp = {
       proto = "tcp",
       port  = "179",
-      cidrs = concat(
-        module.worker_ips.addresses["ipv6cidr"],
-        module.worker_ips.addresses["ipv4cidr"],
-      ),
+      cidrs = local.worker_cidrs,
     }
     vxlan = {
       proto = "udp",
       port  = "4789",
-      cidrs = concat(
-        module.worker_ips.addresses["ipv6cidr"],
-        module.worker_ips.addresses["ipv4cidr"],
-      ),
+      cidrs = local.worker_cidrs,
     }
     kubelet = {
       proto = "tcp",
       port  = "10250",
-      cidrs = concat(
-        module.worker_ips.addresses["ipv6cidr"],
-        module.worker_ips.addresses["ipv4cidr"],
-      ),
+      cidrs = local.worker_cidrs,
     }
     kubeproxy = {
       proto = "tcp",
       port  = "10249",
-      cidrs = concat(
-        module.worker_ips.addresses["ipv6cidr"],
-        module.worker_ips.addresses["ipv4cidr"],
-      ),
+      cidrs = local.worker_cidrs,
     }
     prometheusnodeexporter = {
       proto = "tcp",
       port  = "9100",
-      cidrs = concat(
-        module.worker_ips.addresses["ipv6cidr"],
-        module.worker_ips.addresses["ipv4cidr"],
-      ),
+      cidrs = local.worker_cidrs,
     }
   }
   base_controller_firewall_rules = {

--- a/main.tf
+++ b/main.tf
@@ -115,7 +115,7 @@ locals {
         module.worker_ips.addresses["ipv4cidr"],
       ),
     }
-    prometheus_node_exporter = {
+    prometheusnodeexporter = {
       proto = "tcp",
       port  = "9100",
       cidrs = concat(
@@ -239,6 +239,7 @@ module "k0s" {
   ssh_priv_key_path    = local.ssh_priv_key_path
   controller_addresses = module.controllers.addresses
   worker_addresses     = module.workers.addresses
+  firewall_rules       = local.worker_firewall_rules
 
   cp_balancer_ips = concat(
     module.controller_ips.lb_addresses["ipv4"],

--- a/main.tf
+++ b/main.tf
@@ -77,53 +77,6 @@ module "workers" {
   ip_address_ids    = module.worker_ips.address_ids
   enable_network    = var.enable_private_network
   network_subnet_id = module.controller_ips.subnet_id
-  firewall_rules = {
-    bgp = {
-      proto = "tcp",
-      ports = [179],
-      cidrs = concat(
-        module.worker_ips.addresses["ipv6"],
-        module.worker_ips.addresses["ipv4"],
-        [var.network_subnet_ip_range],
-      ),
-    }
-    vxlan = {
-      proto = "udp",
-      ports = [4789],
-      cidrs = concat(
-        module.worker_ips.addresses["ipv6"],
-        module.worker_ips.addresses["ipv4"],
-        [var.network_subnet_ip_range],
-      ),
-    }
-    kubelet = {
-      proto = "tcp",
-      ports = [10250],
-      cidrs = concat(
-        module.worker_ips.addresses["ipv6"],
-        module.worker_ips.addresses["ipv4"],
-        [var.network_subnet_ip_range],
-      ),
-    }
-    kubeproxy = {
-      proto = "tcp",
-      ports = [10249],
-      cidrs = concat(
-        module.worker_ips.addresses["ipv6"],
-        module.worker_ips.addresses["ipv4"],
-        [var.network_subnet_ip_range],
-      ),
-    }
-    prometheus_node_exporter = {
-      proto = "tcp",
-      ports = [9100],
-      cidrs = concat(
-        module.worker_ips.addresses["ipv6"],
-        module.worker_ips.addresses["ipv4"],
-        [var.network_subnet_ip_range],
-      ),
-    }
-  }
 }
 
 module "controllers" {
@@ -144,12 +97,12 @@ module "controllers" {
   firewall_rules = {
     k8s-api = {
       proto = "tcp",
-      ports = [6443],
+      port  = "6443",
       cidrs = ["0.0.0.0/0"],
     }
     etcd = {
       proto = "tcp",
-      ports = [2380],
+      port  = "2380",
       cidrs = concat(
         module.controller_ips.addresses["ipv6"],
         module.controller_ips.addresses["ipv4"],
@@ -158,7 +111,7 @@ module "controllers" {
     }
     konnectivity = {
       proto = "tcp",
-      ports = [8132, 8133],
+      port  = "8132-8133",
       cidrs = concat(
         module.worker_ips.addresses["ipv6"],
         module.worker_ips.addresses["ipv4"],
@@ -167,7 +120,7 @@ module "controllers" {
     }
     k0s-api = {
       proto = "tcp",
-      ports = [9443],
+      port  = "9443",
       cidrs = concat(
         module.worker_ips.addresses["ipv6"],
         module.worker_ips.addresses["ipv4"],

--- a/modules/k0s/variables.tf
+++ b/modules/k0s/variables.tf
@@ -89,3 +89,13 @@ variable "worker_addresses" {
   description = "A map of objects containing IPv4/IPv6 public and private addresses. Defaults to empty map"
   default     = {}
 }
+
+variable "firewall_rules" {
+  type = map(object({
+    proto = string
+    port  = string
+    cidrs = list(string)
+  }))
+  description = "A map of firewall holes. The keys are arbitrary strings, the values objects with proto, ports, cidrs keys"
+  default     = {}
+}

--- a/modules/network/outputs.tf
+++ b/modules/network/outputs.tf
@@ -2,6 +2,9 @@ output "addresses" {
   value = {
     ipv4 = hcloud_primary_ip.ipv4.*.ip_address,
     ipv6 = hcloud_primary_ip.ipv6.*.ip_address,
+    # The CIDR format is useful in hcloud_firewall resources
+    ipv4cidr = [for a in hcloud_primary_ip.ipv4 : "${a.ip_address}/32"],
+    ipv6cidr = [for a in hcloud_primary_ip.ipv6 : "${a.ip_address}/64"],
   }
 }
 

--- a/modules/server/main.tf
+++ b/modules/server/main.tf
@@ -1,14 +1,6 @@
 locals {
-  enable_ipv6 = length(var.ip_address_ids["ipv6"]) > 0 ? true : false
-  enable_ipv4 = length(var.ip_address_ids["ipv4"]) > 0 ? true : false
-  firewall_rules = {
-    for name, rule in var.firewall_rules :
-    name => {
-      proto = rule.proto,
-      ports = join(" ", rule.ports),
-      cidrs = join(" ", rule.cidrs),
-    }
-  }
+  enable_ipv6   = length(var.ip_address_ids["ipv6"]) > 0 ? true : false
+  enable_ipv4   = length(var.ip_address_ids["ipv4"]) > 0 ? true : false
   role          = replace(var.role, "+", "-")
   network_count = var.enable_network ? var.amount : 0
 }
@@ -37,7 +29,6 @@ resource "hcloud_server" "server" {
         var.hostname != null ? var.hostname : "${local.role}-${count.index}",
         var.domain,
       )
-      firewall_rules = local.firewall_rules,
     }
   )
   ssh_keys = [

--- a/modules/server/templates/user-data.tftpl
+++ b/modules/server/templates/user-data.tftpl
@@ -12,28 +12,9 @@ package_update: true
 package_upgrade: true
 # We don't upgrade even if needed, as it breaks provisioners
 package_reboot_if_required: false
-# Install ferm for firewalling purposes, standard ferm firewalling is pretty strict
 # Install curl cause we 'll need it later
 packages:
-  - ferm
   - curl
-# Pre-populate (before ferm is even installed) ferm configuration file to allow
-# accessing the API
-write_files:
-  %{ for name, rule in firewall_rules }
-  - path: /etc/ferm/ferm.d/${ name }
-    permissions: "0640"
-    owner: "root:root"
-    content: |
-      domain (ip ip6) {
-        table filter {
-          chain INPUT {
-            # allow k8s api connections
-            saddr (${rule.cidrs}) proto ${rule.proto} dport (${rule.ports}) ACCEPT;
-          }
-        }
-      }
-  %{ endfor }
 # Don't allow SSH password auth, only ssh keys
 ssh_pwauth: false
 # Don't expire passwords, hetzner is creating a very strong one at the

--- a/modules/server/variables.tf
+++ b/modules/server/variables.tf
@@ -73,13 +73,11 @@ variable "hostname" {
 variable "firewall_rules" {
   type = map(object({
     proto = string
-    ports = list(number)
+    port  = string
     cidrs = list(string)
   }))
   description = "A map of firewall holes. The keys are arbitrary strings, the values objects with proto, ports, cidrs keys"
-  default = {
-    k8s-api = { proto = "tcp", ports = [6443], cidrs = ["0.0.0.0/0"] }
-  }
+  default     = {}
 }
 
 # Hetzner private network


### PR DESCRIPTION
Why:

Ferm being used in cloud-init has a number of drawbacks we had to deal
with.  The first one was the problematic interactions with kube-router,
which were bypassed using the admittedly more mature Calico as a CNI.
The second one is the fact that whenever we add a worker or controller,
cloud-init changes, require a rebuilt of critical resources of the
cluster, making additions of nodes a downtime inducing process. Moving
ferm rules outside of cloud-init is imperative to solve that

What:

Move to a 2 phased approach. Controllers, when not also workers, will be
protected by Hetzner's firewalling capabilities. Workers, will be
protected by Calico's HostEndpoints functionality. We need this
approach, because controllers aren't nodes of the k0s clusters in many
cases. This kinda ties us closer to Hetzner's infrastructure, but I
think we can safely assume by now that this module is Hetzner only