### PR TITLE
Set up worker plane balancing 

### DIFF
--- a/modules/k0s/variables.md
+++ b/modules/k0s/variables.md
@@ -1,0 +1,57 @@
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_helm"></a> [helm](#requirement\_helm) | 2.10.1 |
+| <a name="requirement_k0s"></a> [k0s](#requirement\_k0s) | 0.2.1 |
+| <a name="requirement_local"></a> [local](#requirement\_local) | 2.4.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_helm"></a> [helm](#provider\_helm) | 2.10.1 |
+| <a name="provider_k0s"></a> [k0s](#provider\_k0s) | 0.2.1 |
+| <a name="provider_local"></a> [local](#provider\_local) | 2.4.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [helm_release.cert-manager](https://registry.terraform.io/providers/hashicorp/helm/2.10.1/docs/resources/release) | resource |
+| [helm_release.hccm](https://registry.terraform.io/providers/hashicorp/helm/2.10.1/docs/resources/release) | resource |
+| [helm_release.hcloud-csi-driver](https://registry.terraform.io/providers/hashicorp/helm/2.10.1/docs/resources/release) | resource |
+| [helm_release.ingress-nginx](https://registry.terraform.io/providers/hashicorp/helm/2.10.1/docs/resources/release) | resource |
+| [helm_release.kube-stack-prometheus](https://registry.terraform.io/providers/hashicorp/helm/2.10.1/docs/resources/release) | resource |
+| [helm_release.terraform-hcloud-k0s-configs](https://registry.terraform.io/providers/hashicorp/helm/2.10.1/docs/resources/release) | resource |
+| [k0s_cluster.k0s](https://registry.terraform.io/providers/alessiodionisi/k0s/0.2.1/docs/resources/cluster) | resource |
+| [local_file.kubeconfig](https://registry.terraform.io/providers/hashicorp/local/2.4.0/docs/resources/file) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_controller_addresses"></a> [controller\_addresses](#input\_controller\_addresses) | A map of objects containing IPv4/IPv6 public and private addresses | <pre>map(object({<br>    public_ipv4  = optional(string),<br>    public_ipv6  = optional(string),<br>    private_ipv4 = optional(string),<br>  }))</pre> | n/a | yes |
+| <a name="input_controller_role"></a> [controller\_role](#input\_controller\_role) | The k0s role for a controller. Values: controller, controller+worker, single | `string` | `"controller"` | no |
+| <a name="input_cp_balancer_ips"></a> [cp\_balancer\_ips](#input\_cp\_balancer\_ips) | If balancing the control-plane, its IPs | `list(string)` | `[]` | no |
+| <a name="input_domain"></a> [domain](#input\_domain) | The domain of all hosts. Will be used to generate all PTRs and names | `string` | n/a | yes |
+| <a name="input_externalIPs"></a> [externalIPs](#input\_externalIPs) | Ingress-nginxs externalIPs setting. Needs to match at least the IPs of the workers | `list(string)` | `[]` | no |
+| <a name="input_firewall_rules"></a> [firewall\_rules](#input\_firewall\_rules) | A map of firewall holes. The keys are arbitrary strings, the values objects with proto, ports, cidrs keys | <pre>map(object({<br>    proto = string<br>    port  = string<br>    cidrs = list(string)<br>  }))</pre> | `{}` | no |
+| <a name="input_hccm_enable"></a> [hccm\_enable](#input\_hccm\_enable) | Whether or not the Hetzner Cloud controller manager will be installed | `bool` | `true` | no |
+| <a name="input_hcloud_token"></a> [hcloud\_token](#input\_hcloud\_token) | Value of the Hetzner token | `string` | n/a | yes |
+| <a name="input_hcsi_enable"></a> [hcsi\_enable](#input\_hcsi\_enable) | Whether or not the Hetzner CSI (Cloud Storage Interface) will be installed | `bool` | `true` | no |
+| <a name="input_hcsi_encryption_key"></a> [hcsi\_encryption\_key](#input\_hcsi\_encryption\_key) | If specified, a Kubernetes StorageClass with LUKS encryption will become available | `string` | `""` | no |
+| <a name="input_k0s_version"></a> [k0s\_version](#input\_k0s\_version) | The version of k0s to target. Default: 1.27.4+k0s.0 | `string` | `"1.27.4+k0s.0"` | no |
+| <a name="input_prometheus_enable"></a> [prometheus\_enable](#input\_prometheus\_enable) | Whether to enable the entire prometheus stack | `bool` | `true` | no |
+| <a name="input_ssh_priv_key_path"></a> [ssh\_priv\_key\_path](#input\_ssh\_priv\_key\_path) | The private part of the above | `string` | n/a | yes |
+| <a name="input_worker_addresses"></a> [worker\_addresses](#input\_worker\_addresses) | A map of objects containing IPv4/IPv6 public and private addresses. Defaults to empty map | <pre>map(object({<br>    public_ipv4  = optional(string),<br>    public_ipv6  = optional(string),<br>    private_ipv4 = optional(string),<br>  }))</pre> | `{}` | no |
+
+## Outputs
+
+No outputs.
+<!-- END_TF_DOCS -->

--- a/modules/network/variables.md
+++ b/modules/network/variables.md
@@ -1,0 +1,67 @@
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_hcloud"></a> [hcloud](#requirement\_hcloud) | 1.42.1 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_hcloud"></a> [hcloud](#provider\_hcloud) | 1.42.1 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [hcloud_load_balancer.lb](https://registry.terraform.io/providers/hetznercloud/hcloud/1.42.1/docs/resources/load_balancer) | resource |
+| [hcloud_load_balancer_network.lb_privnet](https://registry.terraform.io/providers/hetznercloud/hcloud/1.42.1/docs/resources/load_balancer_network) | resource |
+| [hcloud_load_balancer_service.service](https://registry.terraform.io/providers/hetznercloud/hcloud/1.42.1/docs/resources/load_balancer_service) | resource |
+| [hcloud_load_balancer_target.extra](https://registry.terraform.io/providers/hetznercloud/hcloud/1.42.1/docs/resources/load_balancer_target) | resource |
+| [hcloud_load_balancer_target.target](https://registry.terraform.io/providers/hetznercloud/hcloud/1.42.1/docs/resources/load_balancer_target) | resource |
+| [hcloud_network.privnet](https://registry.terraform.io/providers/hetznercloud/hcloud/1.42.1/docs/resources/network) | resource |
+| [hcloud_network_subnet.privnet_subnet](https://registry.terraform.io/providers/hetznercloud/hcloud/1.42.1/docs/resources/network_subnet) | resource |
+| [hcloud_primary_ip.ipv4](https://registry.terraform.io/providers/hetznercloud/hcloud/1.42.1/docs/resources/primary_ip) | resource |
+| [hcloud_primary_ip.ipv6](https://registry.terraform.io/providers/hetznercloud/hcloud/1.42.1/docs/resources/primary_ip) | resource |
+| [hcloud_rdns.ipv4](https://registry.terraform.io/providers/hetznercloud/hcloud/1.42.1/docs/resources/rdns) | resource |
+| [hcloud_rdns.ipv6](https://registry.terraform.io/providers/hetznercloud/hcloud/1.42.1/docs/resources/rdns) | resource |
+| [hcloud_rdns.lb_ipv4](https://registry.terraform.io/providers/hetznercloud/hcloud/1.42.1/docs/resources/rdns) | resource |
+| [hcloud_rdns.lb_ipv6](https://registry.terraform.io/providers/hetznercloud/hcloud/1.42.1/docs/resources/rdns) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_amount"></a> [amount](#input\_amount) | The number of servers | `number` | n/a | yes |
+| <a name="input_balanced_extraIPs"></a> [balanced\_extraIPs](#input\_balanced\_extraIPs) | A list of IPs belonging to non terraform managed resources that are going to be members of the k0s cluster | `list(string)` | `[]` | no |
+| <a name="input_balanced_protocol"></a> [balanced\_protocol](#input\_balanced\_protocol) | The load balanced protocol | `string` | `"tcp"` | no |
+| <a name="input_balanced_services"></a> [balanced\_services](#input\_balanced\_services) | The ports that will get load balanced. NOTE: currently listen and dest port need to be the same | `list(number)` | <pre>[<br>  6443,<br>  8132,<br>  9443<br>]</pre> | no |
+| <a name="input_balancer_type"></a> [balancer\_type](#input\_balancer\_type) | The load balancer type to deploy in front of the created IPs | `string` | `"lb11"` | no |
+| <a name="input_datacenter"></a> [datacenter](#input\_datacenter) | The Hetzner datacenter name to create the server in. Values: nbg1-dc3, fsn1-dc14, hel1-dc2, ash-dc1, hil-dc1. Defaults to fsn1-dc14 | `string` | `"fsn1-dc14"` | no |
+| <a name="input_domain"></a> [domain](#input\_domain) | The domain of all hosts. Will be used to generate all PTRs | `string` | n/a | yes |
+| <a name="input_enable_balancer"></a> [enable\_balancer](#input\_enable\_balancer) | Whether a balancer should be allocated | `bool` | `false` | no |
+| <a name="input_enable_ipv4"></a> [enable\_ipv4](#input\_enable\_ipv4) | Whether an IPv4 address should be allocated | `bool` | `true` | no |
+| <a name="input_enable_ipv6"></a> [enable\_ipv6](#input\_enable\_ipv6) | Whether an IPv6 address should be allocated | `bool` | `true` | no |
+| <a name="input_enable_network"></a> [enable\_network](#input\_enable\_network) | Enable a Hetzner private network | `bool` | `false` | no |
+| <a name="input_hostname"></a> [hostname](#input\_hostname) | You can override the generated name to one of your choose. Only use if spawning up a single server | `string` | `null` | no |
+| <a name="input_network_ip_range"></a> [network\_ip\_range](#input\_network\_ip\_range) | A CIDR in the RFC1918 space for the Hetzner private network. This is an umbrella entity, don't be frugal | `string` | `"10.100.0.0/16"` | no |
+| <a name="input_network_subnet_ip_range"></a> [network\_subnet\_ip\_range](#input\_network\_subnet\_ip\_range) | A CIDR in the RFC1918 space for the Hetzner private network subnet. This needs to be part of the network\_ip\_range | `string` | `"10.100.1.0/24"` | no |
+| <a name="input_network_subnet_type"></a> [network\_subnet\_type](#input\_network\_subnet\_type) | Either cloud of vswitch. vswitch is only possible if you also have a Hetzner Robot vswitch | `string` | `"cloud"` | no |
+| <a name="input_network_vswitch_id"></a> [network\_vswitch\_id](#input\_network\_vswitch\_id) | ID of the vswitch, Required if type is vswitch | `number` | `null` | no |
+| <a name="input_network_zone"></a> [network\_zone](#input\_network\_zone) | The Hetzner network zone. Default to eu-central. | `string` | `"eu-central"` | no |
+| <a name="input_role"></a> [role](#input\_role) | The role of the server. It will be set in labels | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_address_ids"></a> [address\_ids](#output\_address\_ids) | n/a |
+| <a name="output_addresses"></a> [addresses](#output\_addresses) | n/a |
+| <a name="output_lb_addresses"></a> [lb\_addresses](#output\_lb\_addresses) | n/a |
+| <a name="output_subnet_id"></a> [subnet\_id](#output\_subnet\_id) | n/a |
+<!-- END_TF_DOCS -->

--- a/modules/network/variables.tf
+++ b/modules/network/variables.tf
@@ -81,6 +81,12 @@ variable "balanced_protocol" {
   }
 }
 
+variable "balanced_extraIPs" {
+  type        = list(string)
+  description = "A list of IPs belonging to non terraform managed resources that are going to be members of the k0s cluster"
+  default     = []
+}
+
 # Hetzner private network related variables
 variable "enable_network" {
   type        = bool

--- a/modules/server/variables.md
+++ b/modules/server/variables.md
@@ -1,0 +1,51 @@
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_hcloud"></a> [hcloud](#requirement\_hcloud) | 1.42.1 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_hcloud"></a> [hcloud](#provider\_hcloud) | 1.42.1 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [hcloud_firewall.firewall](https://registry.terraform.io/providers/hetznercloud/hcloud/1.42.1/docs/resources/firewall) | resource |
+| [hcloud_firewall_attachment.firewall_attachment](https://registry.terraform.io/providers/hetznercloud/hcloud/1.42.1/docs/resources/firewall_attachment) | resource |
+| [hcloud_placement_group.pg](https://registry.terraform.io/providers/hetznercloud/hcloud/1.42.1/docs/resources/placement_group) | resource |
+| [hcloud_server.server](https://registry.terraform.io/providers/hetznercloud/hcloud/1.42.1/docs/resources/server) | resource |
+| [hcloud_server_network.privnet](https://registry.terraform.io/providers/hetznercloud/hcloud/1.42.1/docs/resources/server_network) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_amount"></a> [amount](#input\_amount) | The number of servers | `number` | n/a | yes |
+| <a name="input_datacenter"></a> [datacenter](#input\_datacenter) | The Hetzner datacenter name to create the server in. Values: nbg1-dc3, fsn1-dc14, hel1-dc2, ash-dc1, hil-dc1. Defaults to fsn1-dc14 | `string` | `"fsn1-dc14"` | no |
+| <a name="input_domain"></a> [domain](#input\_domain) | The domain of all hosts. Will be used to generate all PTRs | `string` | n/a | yes |
+| <a name="input_enable_network"></a> [enable\_network](#input\_enable\_network) | Enable a Hetzner private network | `bool` | `false` | no |
+| <a name="input_firewall_rules"></a> [firewall\_rules](#input\_firewall\_rules) | A map of firewall holes. The keys are arbitrary strings, the values objects with proto, ports, cidrs keys | <pre>map(object({<br>    proto = string<br>    port  = string<br>    cidrs = list(string)<br>  }))</pre> | `{}` | no |
+| <a name="input_hostname"></a> [hostname](#input\_hostname) | You can override the generated name to one of your choose. Only use if spawning up a single server | `string` | `null` | no |
+| <a name="input_image"></a> [image](#input\_image) | The Hetzner cloud server image. Values: debian-11, debian-12. Defaults to debian-12 | `string` | `"debian-12"` | no |
+| <a name="input_ip_address_ids"></a> [ip\_address\_ids](#input\_ip\_address\_ids) | A map of AF\_INET family and list of terraform primary\_ip ids | `map(list(number))` | n/a | yes |
+| <a name="input_network_subnet_id"></a> [network\_subnet\_id](#input\_network\_subnet\_id) | The Hetzner private network subnet id. It should be the one obtained by a call to the child network module | `string` | `null` | no |
+| <a name="input_role"></a> [role](#input\_role) | The role of the server. It will be set in labels | `string` | n/a | yes |
+| <a name="input_ssh_priv_key_path"></a> [ssh\_priv\_key\_path](#input\_ssh\_priv\_key\_path) | The private part of the above | `string` | n/a | yes |
+| <a name="input_ssh_pub_key_id"></a> [ssh\_pub\_key\_id](#input\_ssh\_pub\_key\_id) | The terraform id of SSH key for connecting to servers | `string` | n/a | yes |
+| <a name="input_type"></a> [type](#input\_type) | The Hetzner cloud server type. Defaults to cax11 | `string` | `"cax11"` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_addresses"></a> [addresses](#output\_addresses) | n/a |
+<!-- END_TF_DOCS -->

--- a/variables.md
+++ b/variables.md
@@ -1,3 +1,4 @@
+<!-- BEGIN_TF_DOCS -->
 ## Requirements
 
 | Name | Version |
@@ -36,6 +37,7 @@
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_balance_control_plane"></a> [balance\_control\_plane](#input\_balance\_control\_plane) | Whether the control plane will be load balanced. Needs > 1 controller | `bool` | `false` | no |
+| <a name="input_balance_worker_plane"></a> [balance\_worker\_plane](#input\_balance\_worker\_plane) | Whether the control plane will be load balanced. Needs > 1 worker | `bool` | `false` | no |
 | <a name="input_controller_count"></a> [controller\_count](#input\_controller\_count) | The number of controllers. Defaults to 3 | `number` | `3` | no |
 | <a name="input_controller_role"></a> [controller\_role](#input\_controller\_role) | The k0s role for a controller. Values: controller, controller+worker, single | `string` | `"controller"` | no |
 | <a name="input_controller_server_datacenter"></a> [controller\_server\_datacenter](#input\_controller\_server\_datacenter) | The Hetzner datacenter name to create the server in. Values: nbg1-dc3, fsn1-dc14, hel1-dc2, ash-dc1 or hil-dc1 | `string` | `"fsn1-dc14"` | no |
@@ -72,3 +74,4 @@
 | <a name="output_controller_ip_addresses"></a> [controller\_ip\_addresses](#output\_controller\_ip\_addresses) | n/a |
 | <a name="output_lb_ip_addresses"></a> [lb\_ip\_addresses](#output\_lb\_ip\_addresses) | n/a |
 | <a name="output_worker_ip_addresses"></a> [worker\_ip\_addresses](#output\_worker\_ip\_addresses) | n/a |
+<!-- END_TF_DOCS -->

--- a/variables.tf
+++ b/variables.tf
@@ -28,6 +28,12 @@ variable "balance_control_plane" {
   default     = false
 }
 
+variable "balance_worker_plane" {
+  type        = bool
+  description = "Whether the control plane will be load balanced. Needs > 1 worker"
+  default     = false
+}
+
 variable "prometheus_enable" {
   type        = bool
   description = "Whether to enable the entire prometheus stack"


### PR DESCRIPTION
Add support to balance ports 80 and 443 of the worker plane.
Make sure to support extra worker nodes in the pool of workers.
